### PR TITLE
updated package.json for react-native >= 0.60

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "author": "Tommy Chung <tom555my@gmail.com>",
     "license": "MIT",
     "devDependencies": {
-        "@types/react": "^16.7.18",
-        "@types/react-dom": "^16.0.11",
-        "@types/react-native": "^0.57.26",
+        "@types/react": "^16.8.16",
+        "@types/react-dom": "^16.8.6",
+        "@types/react-native": "^0.60.5",
         "typescript": "^3.2.2"
     },
     "dependencies": {
         "avataaars": "^1.2.1",
-        "react-native-remote-svg": "^1.4.0"
+        "react-native-remote-svg": "^2.0.6"
     }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     },
     "dependencies": {
         "avataaars": "^1.2.1",
-        "react-native-remote-svg": "^2.0.6"
+        "react-native-remote-svg": "Ingibjorg/react-native-remote-svg#issue-53-migrate-from-deprecated-uiwebview"
     }
 }


### PR DESCRIPTION
Webview can't be used inReact-Native >=0.60 anymore. That's why we have to switch to React-Native-Remote-Svg >=2.0.0  My only problem is, that i require to install Webview separately in my own project. If there is a way to automatically do this let me know.